### PR TITLE
Fix error in usage of the normals method after the change in 4a31bca

### DIFF
--- a/qed_splatter/model.py
+++ b/qed_splatter/model.py
@@ -820,7 +820,7 @@ class QEDSplatterModel(SplatfactoModel):
                 )
             elif return_normal == "closest_gaussian":
                 points_closest_gaussians_idx = closest_gaussians_idx[~empty_pixels]
-                intersection_normals = self.normals[
+                intersection_normals = self.normals()[
                     points_closest_gaussians_idx[..., 0]
                 ]
             else:


### PR DESCRIPTION
The fix for #1 breaks the mesh extraction pipeline, this resolves an issue caused by the change to the `normals` method