### PR TITLE
Fixed metric calculation for RGBA images

### DIFF
--- a/qed_splatter/model.py
+++ b/qed_splatter/model.py
@@ -317,7 +317,7 @@ class QEDSplatterModel(SplatfactoModel):
                 sensor_depth_gt = batch["depth_image"]
 
         metrics_dict = {}
-        gt_rgb = gt_img.to(self.device)  # RGB or RGBA image
+        gt_rgb = gt_img[..., :3].to(self.device)  # RGB or RGBA image
         predicted_rgb = (
             outputs["rgb"][0, ...] if outputs["rgb"].dim() == 4 else outputs["rgb"]
         )


### PR DESCRIPTION
Fixed metric calculation for RGBA images, removing the following error.

<img width="1108" height="890" alt="image" src="https://github.com/user-attachments/assets/de3aac5c-1042-413c-92c9-7ea8a05c6d7b" />
